### PR TITLE
Adding optional host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ import 'package:pusher_dart/pusher_dart.dart';
 final pusher = Pusher(
     DotEnv().env['PUSHER_APP_KEY'],
     PusherOptions(
+        //host:'10.0.2.2',   //optional
+        //port:6001,        //optional
         authEndpoint: DotEnv().env['PUSHER_AUTH_URL'],
         auth: PusherAuth(headers: {
           'Authorization': 'Bearer $apiToken',


### PR DESCRIPTION
In case someone want's to use another host than the pusher server (e.g. self hosted - see https://docs.beyondco.de/laravel-websockets/)
he can do so now. 

Tested both with the offical pusher server and a self hosted one (from the link). Both work.